### PR TITLE
WIP: Measurement Code Update

### DIFF
--- a/src/mnt_setup_fnc.cpp
+++ b/src/mnt_setup_fnc.cpp
@@ -1,9 +1,12 @@
+
 #include <TChain.h>
 #include <TCanvas.h>
 #include <TH1F.h>
 #include <THStack.h>
 #include <string>
+#include <vector>
 #include <iostream>
+
 
 std::string const DATADIR = "/storage/epp2/phshgg/DVTuples__v23/";
 
@@ -16,33 +19,47 @@ struct path_data {
 	stream;
 };
 
-struct input {
+struct plot_config {
 	std::string const expression;
 	int const nbins;
 	float const xmin,
 	xmax;
 	std::string const label,
 	unit;
+
+  //create constructor to allow struct to configure correctly in the emplace_back function
+  plot_config(std::string const expression, int const nbins, float const xmin, float const xmax, std::string const label, std::string const unit)
+    :expression(std::move(expression))
+    ,nbins(nbins)
+    ,xmin(xmin)
+    ,xmax(xmax)
+    ,label(std::move(label))
+    ,unit(std::move(unit))
+  {}
 };
 
-TH1F* make_TH1F(struct path_data path_in, struct input hist_input, std::string hist_name, std::string hist_setup) {
+std::vector<plot_config> plot_configurations;
+
+
+TH1F* make_TH1F(struct path_data path_in, struct plot_config hist_input, std::string hist_name, std::string hist_text) {
 	TChain ch("Z/DecayTree");
 	std::string path = path_in.DATADIR + path_in.sqrts + "TeV_" + path_in.year + "_" + path_in.stripping + "_" + path_in.polarity + "_" + path_in.stream + ".root";
 	ch.Add(path.c_str());
 	
-	TH1F *hist = new TH1F(hist_name.c_str(), hist_setup.c_str(), hist_input.nbins, hist_input.xmin, hist_input.xmax);
+	TH1F *hist = new TH1F(hist_name.c_str(), hist_text.c_str(), hist_input.nbins, hist_input.xmin, hist_input.xmax);
 	std::string expression = hist_input.expression +">>"+ hist->GetName();
 	ch.Draw(expression.c_str());
 	return hist;
 }
 
-void plot_histogram(struct path_data mnt_in, struct path_data sim_in, struct input hist_input) {
+void plot_data_sim(struct path_data mnt_in, struct path_data sim_in, struct plot_config hist_input) {
 	std::string hist_title = "Measurement vs Simulation for " + hist_input.label,
-		x_axis = hist_input.label + " " + hist_input.unit,
-		hist_text = hist_title + ";" + x_axis;
-	
-	TH1F *hist_mnt = make_TH1F(mnt_in, hist_input, "measurement", hist_text);
-	TH1F *hist_sim = make_TH1F(sim_in, hist_input, "simulation", hist_text);
+	  x_axis = hist_input.label + " " + hist_input.unit,
+	  sim_text = hist_input.label + " Simulation Data;" + x_axis,
+	  mnt_text = hist_input.label + " Experimental Data;" + x_axis;
+
+	TH1F *hist_mnt = make_TH1F(mnt_in, hist_input, "measurement", mnt_text);
+	TH1F *hist_sim = make_TH1F(sim_in, hist_input, "simulation", sim_text);
 	
 	hist_sim->Scale(hist_mnt->Integral()/hist_sim->Integral());
 	
@@ -50,7 +67,9 @@ void plot_histogram(struct path_data mnt_in, struct path_data sim_in, struct inp
 	hist_sim->SetStats(false);
 	hist_sim->Draw("HIST");
 	hist_mnt->Draw("SAME E");
-	std::string const filename = "Measurement_" + hist_input.label + ".png";
+	hist_mnt->SetLineColor(2);
+	canv.BuildLegend();
+	std::string const filename = "Measurement_" + hist_input.label + ".pdf";
 	canv.SaveAs(filename.c_str());
 }
 
@@ -61,35 +80,22 @@ int main() {
 
 	/*Simulation Chain*/
 	path_data const simulation_in = {DATADIR, "13", "28r1", "2016", "Down", "Z_Sim09h"};
+
 	
-	
-	/*input property_in = {"expression", nbins, xmin., xmax., "label", "unit"};
-	plot_histogram(measurement_in, simulation_in, property_in);*/
-	
-	/*mup*/
-	input const mup_PT_in = {"1.e-3*mup_PT", 100, 15., 60., "mup_PT", "(GeV)"};
-	plot_histogram(measurement_in, simulation_in, mup_PT_in);
-	
-	input const mup_ETA_in = {"mup_ETA", 100, 1.5, 5., "mup_ETA", ""};
-	plot_histogram(measurement_in, simulation_in, mup_ETA_in);
-	
-	input const mup_PHI_in = {"mup_PHI", 100, -4., 4., "mup_PHI", ""};
-	plot_histogram(measurement_in, simulation_in, mup_PHI_in);
-	
-	/*mum*/
-	input const mum_PT_in = {"1.e-3*mum_PT", 100, 15., 60., "mum_PT", "(GeV)"};
-	plot_histogram(measurement_in, simulation_in, mum_PT_in);
-	
-	input const mum_ETA_in = {"mum_ETA", 100, 1.5, 5., "mum_ETA", ""};
-	plot_histogram(measurement_in, simulation_in, mum_ETA_in);
-	
-	input const mum_PHI_in = {"mum_PHI", 100, -4., 4., "mum_PHI", ""};
-	plot_histogram(measurement_in, simulation_in, mum_PHI_in);
-	
-	/*dimuon*/
-	input const Z_M_in = {"1.e-3*Z_M", 100, 35, 120, "Z_M", "(GeV)"};
-	plot_histogram(measurement_in, simulation_in, Z_M_in);
-	
+	//mup
+	plot_configurations.emplace_back("1.e-3*mup_PT", 100, 15., 60., "mup_PT", "(GeV)");
+	plot_configurations.emplace_back("mup_ETA", 100, 1.5, 5., "mup_ETA", "");
+	plot_configurations.emplace_back("mup_PHI", 100, -4., 4., "mup_PHI", "");
+	//mum
+	plot_configurations.emplace_back("1.e-3*mum_PT", 100, 15., 60., "mum_PT", "(GeV)");
+	plot_configurations.emplace_back("mum_ETA", 100, 1.5, 5., "mum_ETA", "");
+	plot_configurations.emplace_back("mum_PHI", 100, -4., 4., "mum_PHI", "");
+	//dimuon
+	plot_configurations.emplace_back("1.e-3*Z_M", 100, 35, 120, "Z_M", "(GeV)");
+
+	for (auto const & plot_configuration : plot_configurations) {
+	  plot_data_sim(measurement_in, simulation_in, plot_configuration);
+	}
 	
 	return 0;
 }

--- a/src/mnt_setup_fnc.cpp
+++ b/src/mnt_setup_fnc.cpp
@@ -1,4 +1,3 @@
-
 #include <TChain.h>
 #include <TCanvas.h>
 #include <TH1F.h>
@@ -49,25 +48,41 @@ TH1F* make_TH1F(struct path_data path_in, struct plot_config hist_input, std::st
 	TH1F *hist = new TH1F(hist_name.c_str(), hist_text.c_str(), hist_input.nbins, hist_input.xmin, hist_input.xmax);
 	std::string expression = hist_input.expression +">>"+ hist->GetName();
 	ch.Draw(expression.c_str());
+	hist->SetTitle("");
 	return hist;
 }
 
 void plot_data_sim(struct path_data mnt_in, struct path_data sim_in, struct plot_config hist_input) {
-	std::string hist_title = "Measurement vs Simulation for " + hist_input.label,
-	  x_axis = hist_input.label + " " + hist_input.unit,
+
+        std::string x_axis = hist_input.label + " " + hist_input.unit,
 	  sim_text = hist_input.label + " Simulation Data;" + x_axis,
 	  mnt_text = hist_input.label + " Experimental Data;" + x_axis;
+	//std::string hist_title = "Measurement vs Simulation for " + hist_input.label;
 
 	TH1F *hist_mnt = make_TH1F(mnt_in, hist_input, "measurement", mnt_text);
 	TH1F *hist_sim = make_TH1F(sim_in, hist_input, "simulation", sim_text);
 	
+	hist_mnt->SetName("Experimental Data");
+	hist_sim->SetName("Simulation Data");
+
 	hist_sim->Scale(hist_mnt->Integral()/hist_sim->Integral());
 	
+	float ymax,
+	  ymax_mnt = hist_mnt->GetMaximum(),
+	  ymax_sim = hist_sim->GetMaximum();
+	if (ymax_mnt > ymax_sim) {
+	  ymax = 1.15*ymax_mnt;
+	}
+	else {
+	  ymax = 1.15*ymax_sim;
+	}
+
 	TCanvas canv;
-	hist_sim->SetStats(false);
-	hist_sim->Draw("HIST");
-	hist_mnt->Draw("SAME E");
-	hist_mnt->SetLineColor(2);
+	hist_mnt->SetStats(false);
+	hist_mnt->Draw("E");
+	hist_sim->Draw("SAME HIST");
+     	hist_mnt->GetYaxis()->SetRangeUser(0,ymax);
+	hist_sim->SetLineColor(kAzure);
 	canv.BuildLegend();
 	std::string const filename = "Measurement_" + hist_input.label + ".pdf";
 	canv.SaveAs(filename.c_str());

--- a/src/mnt_setup_fnc.cpp
+++ b/src/mnt_setup_fnc.cpp
@@ -8,59 +8,88 @@
 std::string const DATADIR = "/storage/epp2/phshgg/DVTuples__v23/";
 
 struct path_data {
-	std::string const DATADIR;
-	std::string sqrts,
+	std::string const DATADIR,
+	sqrts,
 	stripping,
 	year,
 	polarity,
 	stream;
 };
 
-void make_histogram(struct path_data path_in, std::string hist_name, std::string hist_setup, int const nbins, float const xmin, float const xmax, std::string expression, THStack *hist_stack) {
+struct input {
+	std::string const expression;
+	int const nbins;
+	float const xmin,
+	xmax;
+	std::string const label,
+	unit;
+};
+
+TH1F* make_TH1F(struct path_data path_in, struct input hist_input, std::string hist_name, std::string hist_setup) {
 	TChain ch("Z/DecayTree");
 	std::string path = path_in.DATADIR + path_in.sqrts + "TeV_" + path_in.year + "_" + path_in.stripping + "_" + path_in.polarity + "_" + path_in.stream + ".root";
 	ch.Add(path.c_str());
 	
-	TH1F *hist = new TH1F(hist_name.c_str(), hist_setup.c_str(), nbins, xmin, xmax);
-	expression += hist->GetName();
+	TH1F *hist = new TH1F(hist_name.c_str(), hist_setup.c_str(), hist_input.nbins, hist_input.xmin, hist_input.xmax);
+	std::string expression = hist_input.expression +">>"+ hist->GetName();
 	ch.Draw(expression.c_str());
-	hist_stack->Add(hist);
+	return hist;
 }
 
+void plot_histogram(struct path_data mnt_in, struct path_data sim_in, struct input hist_input) {
+	std::string hist_title = "Measurement vs Simulation for " + hist_input.label,
+		x_axis = hist_input.label + " " + hist_input.unit,
+		hist_text = hist_title + ";" + x_axis;
+	
+	TH1F *hist_mnt = make_TH1F(mnt_in, hist_input, "measurement", hist_text);
+	TH1F *hist_sim = make_TH1F(sim_in, hist_input, "simulation", hist_text);
+	
+	hist_sim->Scale(hist_mnt->Integral()/hist_sim->Integral());
+	
+	TCanvas canv;
+	hist_sim->SetStats(false);
+	hist_sim->Draw("HIST");
+	hist_mnt->Draw("SAME E");
+	std::string const filename = "Measurement_" + hist_input.label + ".png";
+	canv.SaveAs(filename.c_str());
+}
 
 int main() {
 
 	/*Measurement Chain*/
-	path_data measurement_in = {DATADIR, "5", "32", "2017", "Down", "EW"};
+	path_data const measurement_in = {DATADIR, "5", "32", "2017", "Down", "EW"};
 
 	/*Simulation Chain*/
-	path_data simulation_in = {DATADIR, "13", "28r1", "2016", "Down", "Z_Sim09h"};
+	path_data const simulation_in = {DATADIR, "13", "28r1", "2016", "Down", "Z_Sim09h"};
 	
-	/*Branch Input*/
-	std::string const muon_prop = "mum_PHI",
-		muon_prop_unit = " ";
 	
-	/*Histogram Set-up*/
-	std::string hist_title = "Measurement vs Simulation for " + muon_prop,
-		x_axis = muon_prop + muon_prop_unit,
-		hist_setup = hist_title + ";" + x_axis,
-		expression = muon_prop + ">>";
-		/*expression = "1.e-3*" + muon_prop + ">>"; version for PT in GeV*/
+	/*input property_in = {"expression", nbins, xmin., xmax., "label", "unit"};
+	plot_histogram(measurement_in, simulation_in, property_in);*/
 	
-	int const nbins = 100;
-	float const xmin = -4.,
-		xmax = 4.;
+	/*mup*/
+	input const mup_PT_in = {"1.e-3*mup_PT", 100, 15., 60., "mup_PT", "(GeV)"};
+	plot_histogram(measurement_in, simulation_in, mup_PT_in);
 	
-	/*Make Histogram*/
-	THStack *hist_main = new THStack(muon_prop.c_str(), hist_setup.c_str());
+	input const mup_ETA_in = {"mup_ETA", 100, 1.5, 5., "mup_ETA", ""};
+	plot_histogram(measurement_in, simulation_in, mup_ETA_in);
 	
-	make_histogram(measurement_in, "measurement", hist_setup, nbins, xmin, xmax, expression, hist_main);
-	make_histogram(simulation_in, "simulation", hist_setup, nbins, xmin, xmax, expression, hist_main);
+	input const mup_PHI_in = {"mup_PHI", 100, -4., 4., "mup_PHI", ""};
+	plot_histogram(measurement_in, simulation_in, mup_PHI_in);
 	
-	TCanvas canv;
-	hist_main->Draw("E");
-	std::string const filename = "Measurement_" + muon_prop + ".pdf";
-	canv.SaveAs(filename.c_str());
+	/*mum*/
+	input const mum_PT_in = {"1.e-3*mum_PT", 100, 15., 60., "mum_PT", "(GeV)"};
+	plot_histogram(measurement_in, simulation_in, mum_PT_in);
+	
+	input const mum_ETA_in = {"mum_ETA", 100, 1.5, 5., "mum_ETA", ""};
+	plot_histogram(measurement_in, simulation_in, mum_ETA_in);
+	
+	input const mum_PHI_in = {"mum_PHI", 100, -4., 4., "mum_PHI", ""};
+	plot_histogram(measurement_in, simulation_in, mum_PHI_in);
+	
+	/*dimuon*/
+	input const Z_M_in = {"1.e-3*Z_M", 100, 35, 120, "Z_M", "(GeV)"};
+	plot_histogram(measurement_in, simulation_in, Z_M_in);
+	
 	
 	return 0;
 }

--- a/src/mnt_setup_fnc.cpp
+++ b/src/mnt_setup_fnc.cpp
@@ -48,22 +48,23 @@ TH1F* make_TH1F(struct path_data path_in, struct plot_config hist_input, std::st
 	TH1F *hist = new TH1F(hist_name.c_str(), hist_text.c_str(), hist_input.nbins, hist_input.xmin, hist_input.xmax);
 	std::string expression = hist_input.expression +">>"+ hist->GetName();
 	ch.Draw(expression.c_str());
-	hist->SetTitle("");
+	//hist->SetTitle("");
 	return hist;
 }
 
 void plot_data_sim(struct path_data mnt_in, struct path_data sim_in, struct plot_config hist_input) {
 
         std::string x_axis = hist_input.label + " " + hist_input.unit,
-	  sim_text = hist_input.label + " Simulation Data;" + x_axis,
-	  mnt_text = hist_input.label + " Experimental Data;" + x_axis;
+	  sim_name = hist_input.label + " Simulation Data",
+	  hist_text = ";" + x_axis,
+	  mnt_name = hist_input.label + " Experimental Data";
 	//std::string hist_title = "Measurement vs Simulation for " + hist_input.label;
 
-	TH1F *hist_mnt = make_TH1F(mnt_in, hist_input, "measurement", mnt_text);
-	TH1F *hist_sim = make_TH1F(sim_in, hist_input, "simulation", sim_text);
+	TH1F *hist_mnt = make_TH1F(mnt_in, hist_input, "measurement", hist_text);
+	TH1F *hist_sim = make_TH1F(sim_in, hist_input, "simulation", hist_text);
 	
-	hist_mnt->SetName("Experimental Data");
-	hist_sim->SetName("Simulation Data");
+	hist_mnt->SetName(mnt_name.c_str());
+	hist_sim->SetName(sim_name.c_str());
 
 	hist_sim->Scale(hist_mnt->Integral()/hist_sim->Integral());
 	


### PR DESCRIPTION
@mvesteri 
Here's the mnt_setup_fnc.cpp code from this afternoon, updated with the changes you suggested in the meeting (see Issue #7)
Code is now generalised, producing a normalised plot in a function, and called for Z_M, and PT, ETA, PHI for mup and mum. 
I could not find a branch for dimuon PT or rapidity using the ROOT Browser, so haven't yet plotted those.

I've attached the produced plot for Z_M as an example.
![Measurement_Z_M](https://user-images.githubusercontent.com/72559837/97929768-c6d7d980-1d61-11eb-9ceb-d6a9376ac606.png)

Closes Issue #7 