### PR TITLE
Z Cross Section with Trigger Efficiency

### DIFF
--- a/scripts/get_luminosity.py
+++ b/scripts/get_luminosity.py
@@ -22,6 +22,6 @@ print('IL 5% error (pb-1) = {}'.format(total_lumi_err))
 
 data = {'luminosity':total_lumi, 'luminosity_err':total_lumi_err}
 
-with open('luminosity.txt', 'w') as outfile:
+with open('luminosity.json', 'w') as outfile:
     json.dump(data,outfile)
 

--- a/scripts/get_luminosity.py
+++ b/scripts/get_luminosity.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+from ROOT import gROOT
+gROOT.SetBatch(True)
+import ROOT
+import json
+
+data = {}
+
+file_path = "/storage/epp2/phshgg/DVTuples__v23/5TeV_2017_32_Down_EW.root"
+
+rfile = ROOT.TFile(file_path)
+lumi_tuple = rfile.Get('GetIntegratedLuminosity/LumiTuple')
+
+total_lumi = 0.0
+
+total_lumi = sum([entry.IntegratedLuminosity for entry in lumi_tuple])
+  
+total_lumi_err = total_lumi*0.05
+
+print('Integrated Luminosity (pb-1) = {}'.format(total_lumi))
+print('IL 5% error (pb-1) = {}'.format(total_lumi_err))
+
+data = {'luminosity':total_lumi, 'luminosity_err':total_lumi_err}
+
+with open('data.txt', 'w') as outfile:
+    json.dump(data,outfile)
+

--- a/scripts/get_luminosity.py
+++ b/scripts/get_luminosity.py
@@ -22,6 +22,6 @@ print('IL 5% error (pb-1) = {}'.format(total_lumi_err))
 
 data = {'luminosity':total_lumi, 'luminosity_err':total_lumi_err}
 
-with open('data.txt', 'w') as outfile:
+with open('luminosity.txt', 'w') as outfile:
     json.dump(data,outfile)
 

--- a/scripts/measure_trigger_eff.py
+++ b/scripts/measure_trigger_eff.py
@@ -2,6 +2,9 @@
 from ROOT import gROOT
 gROOT.SetBatch(True)
 import ROOT
+import json
+
+data = {}
 
 file_path = "/storage/epp2/phshgg/DVTuples__v23/5TeV_2017_32_Down_EW.root"
 
@@ -16,14 +19,14 @@ both_trigger = float(ch.GetEntries("mup_L0MuonDecision_TOS == 1 && mum_L0MuonDec
 mup_eff = both_trigger/mum_trigger
 mum_eff = both_trigger/mup_trigger
 
-both_eff = 2*both_trigger/(mum_trigger+mup_trigger)
+mup_mum_eff = mup_eff * mum_eff
 
-mup_mum_eff = mup_eff + mum_eff - both_eff
+print("Trigger Efficiency = {}".format(mup_mum_eff))
 
-print(mup_trigger)
-print(mum_trigger)
-print(both_trigger)
-print(mup_eff)
-print(mum_eff)
-print(both_eff)
-print(mup_mum_eff)
+data ={"trigger_efficiency":mup_mum_eff}
+
+with open('data.txt', 'r+') as outfile:
+    data_file = json.load(outfile)
+    data_file.update(data)
+    outfile.seek(0)
+    json.dump(data_file,outfile)

--- a/scripts/measure_trigger_eff.py
+++ b/scripts/measure_trigger_eff.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+from ROOT import gROOT
+gROOT.SetBatch(True)
+import ROOT
+
+file_path = "/storage/epp2/phshgg/DVTuples__v23/5TeV_2017_32_Down_EW.root"
+
+ch = ROOT.TChain('Z/DecayTree')
+ch.Add(file_path)
+
+mup_trigger = float(ch.GetEntries("mup_L0MuonDecision_TOS == 1"))
+mum_trigger = float(ch.GetEntries("mum_L0MuonDecision_TOS == 1"))
+both_trigger = float(ch.GetEntries("mup_L0MuonDecision_TOS == 1 && mum_L0MuonDecision_TOS == 1"))
+
+
+mup_eff = both_trigger/mum_trigger
+mum_eff = both_trigger/mup_trigger
+
+both_eff = 2*both_trigger/(mum_trigger+mup_trigger)
+
+mup_mum_eff = mup_eff + mum_eff - both_eff
+
+print(mup_trigger)
+print(mum_trigger)
+print(both_trigger)
+print(mup_eff)
+print(mum_eff)
+print(both_eff)
+print(mup_mum_eff)

--- a/scripts/measure_trigger_eff.py
+++ b/scripts/measure_trigger_eff.py
@@ -19,14 +19,11 @@ both_trigger = float(ch.GetEntries("mup_L0MuonDecision_TOS == 1 && mum_L0MuonDec
 mup_eff = both_trigger/mum_trigger
 mum_eff = both_trigger/mup_trigger
 
-mup_mum_eff = mup_eff * mum_eff
+mup_mum_eff = mup_eff + mum_eff - mup_eff * mum_eff
 
 print("Trigger Efficiency = {}".format(mup_mum_eff))
 
-data ={"trigger_efficiency":mup_mum_eff}
+data ={"mup":mup_eff, "mum":mum_eff, "trigger_efficiency":mup_mum_eff}
 
-with open('data.txt', 'r+') as outfile:
-    data_file = json.load(outfile)
-    data_file.update(data)
-    outfile.seek(0)
-    json.dump(data_file,outfile)
+with open('efficiencies.txt', 'w') as outfile:
+    json.dump(data,outfile)

--- a/scripts/measure_trigger_eff.py
+++ b/scripts/measure_trigger_eff.py
@@ -25,5 +25,5 @@ print("Trigger Efficiency = {}".format(mup_mum_eff))
 
 data ={"mup":mup_eff, "mum":mum_eff, "trigger_efficiency":mup_mum_eff}
 
-with open('efficiencies.txt', 'w') as outfile:
+with open('efficiencies.json', 'w') as outfile:
     json.dump(data,outfile)

--- a/scripts/measure_xsec.py
+++ b/scripts/measure_xsec.py
@@ -11,12 +11,16 @@ ch.Add(file_path)
 
 count = ch.GetEntries("Z_M > 60.e3 && Z_M < 120.e3 && mup_PT > 20.e3 && mum_PT > 20.e3 && mup_ETA > 2 && mup_ETA < 4.5 && mum_ETA > 2 && mum_ETA < 4.5")
 
-with open('data.txt') as json_file:
-    data = json.load(json_file)
+with open('luminosity.txt') as json_file:
+    luminosity = json.load(json_file)
 
-lumi = data["luminosity"]
-lumi_err = data["luminosity_err"]
-trig_eff = data["trigger_efficiency"]
+lumi = luminosity["luminosity"]
+lumi_err = luminosity["luminosity_err"]
+
+with open('efficiencies.txt') as json_file:
+    efficiencies = json.load(json_file)
+
+trig_eff = efficiencies["trigger_efficiency"]
 
 xsec = count/(lumi*trig_eff)
 xsec_err = xsec - count/((lumi+lumi_err)*trig_eff)

--- a/scripts/measure_xsec.py
+++ b/scripts/measure_xsec.py
@@ -11,13 +11,13 @@ ch.Add(file_path)
 
 count = ch.GetEntries("Z_M > 60.e3 && Z_M < 120.e3 && mup_PT > 20.e3 && mum_PT > 20.e3 && mup_ETA > 2 && mup_ETA < 4.5 && mum_ETA > 2 && mum_ETA < 4.5")
 
-with open('luminosity.txt') as json_file:
+with open('luminosity.json') as json_file:
     luminosity = json.load(json_file)
 
 lumi = luminosity["luminosity"]
 lumi_err = luminosity["luminosity_err"]
 
-with open('efficiencies.txt') as json_file:
+with open('efficiencies.json') as json_file:
     efficiencies = json.load(json_file)
 
 trig_eff = efficiencies["trigger_efficiency"]

--- a/scripts/measure_xsec.py
+++ b/scripts/measure_xsec.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+from ROOT import gROOT
+gROOT.SetBatch(True)
+import ROOT
+import json
+
+file_path = "/storage/epp2/phshgg/DVTuples__v23/5TeV_2017_32_Down_EW.root"
+
+ch = ROOT.TChain('Z/DecayTree')
+ch.Add(file_path)
+
+count = ch.GetEntries("Z_M > 60.e3 && Z_M < 120.e3 && mup_PT > 20.e3 && mum_PT > 20.e3 && mup_ETA > 2 && mup_ETA < 4.5 && mum_ETA > 2 && mum_ETA < 4.5")
+
+with open('data.txt') as json_file:
+    data = json.load(json_file)
+
+lumi = data["luminosity"]
+lumi_err = data["luminosity_err"]
+trig_eff = data["trigger_efficiency"]
+
+xsec = count/(lumi*trig_eff)
+xsec_err = xsec - count/((lumi+lumi_err)*trig_eff)
+
+print('Z Count = {}'.format(count))
+print('Z Cross Section (pb) = {}'.format(xsec))
+print('XSec Error (pb) = {}'.format(xsec_err))

--- a/scripts/run_xsec_analysis.sh
+++ b/scripts/run_xsec_analysis.sh
@@ -1,3 +1,6 @@
-make
+#make
 ./plot_MC_comparison.exe
-./scripts/measure_xsec_lumi.py
+./scripts/get_luminosity.py
+./scripts/measure_trigger_eff.py
+./scripts/measure_xsec.py
+

--- a/scripts/run_xsec_analysis.sh
+++ b/scripts/run_xsec_analysis.sh
@@ -1,4 +1,4 @@
-#make
+make
 ./plot_MC_comparison.exe
 ./scripts/get_luminosity.py
 ./scripts/measure_trigger_eff.py


### PR DESCRIPTION
Closes #18 
@mvesteri 
Pull request contains code to calculate trigger efficiency, and updated code to calculate Z cross section using this.

- The previous Z cross section calculation code [measure_xsec_lumi.py](https://github.com/r-preston/MPhysProject2021/blob/master/scripts/measure_xsec_lumi.py) has been split into two separate codes calculating the luminosity and cross section separately, using json to pass the values between files:
- Luminosity and trigger efficiency codes write to file "data.txt", which is read into the cross section calculation in measure_xsec.py
- Top level code has been updated to reflect this

Outputs:
Trigger efficiency = 0.873 (to 3sf)
Z Cross Section = 66±3 pb