### PR TITLE
W xsec improvement: Trigger Efficiency

### DIFF
--- a/doc/measurement_doc/measurement_report.tex
+++ b/doc/measurement_doc/measurement_report.tex
@@ -45,7 +45,7 @@
 
 \section{Z Cross Section from 5TeV Experimental Data} \label{results}
 
-The LHCb dataset used in this analysis has been taken at $\sqrt{s} = 5$ TeV. The dataset contains 5840 entries corresponding to $Z$ events. The workflow of the code used to analyse this data is given in Section \ref{workflow}, with results given in Section \ref{results}, and plot given in Section \ref{Z histograms}.
+The LHCb dataset used in this analysis has been taken at $\sqrt{s} = 5$ TeV. The dataset contains 5840 entries. The workflow of the code used to analyse this data is given in Section \ref{workflow}, with results given in Section \ref{results}, and plots given in Section \ref{Z histograms}.
 
 \subsection{Integrated Luminosity} \label{lumi_val}
 \input{results/lumi_output.tex}
@@ -72,29 +72,45 @@ The variables compared are:
   \item Dimuon invariant mass $M_{\mu\mu}$, equivalent to the mass of the Z boson $m_Z$
 \end{itemize}
 
-Differences can be seen between the experimental and simulated data due to background in the experimental data, and inaccuracies in the simulation. These inaccuracies arise due to the leading order precision of \textit{Pythia} and limits on the precision to which the detector can be described.
+Differences can be seen between the experimental and simulated data due to background in the experimental data, and inaccuracies in the simulation. These inaccuracies arise due to the leading order precision of \textit{Pythia} and limits on the precision to which the detector can be described. 
+Comparing these plots tests the validity of using the simulation in determination of $W$ boson background.
 
 See plots in Section \ref{Z histograms}.
 
 \subsection{Luminosity Calculation} \label{sec: Z lumi}
 The code \texttt{get$\_$luminosity.py} calculates the integrated luminosity $L$ as the sum of 38 entries, where each entry represents a fraction of the data collected in the 5 TeV run.
 The error on luminosity is assumed to be 5$\%$.
-Integrated luminosity and its error are output as a json file, with their values given in Section \ref{lumi_val}.
+Integrated luminosity and its error are output as a json file ``luminosity.json", with their values given in Section~\ref{lumi_val}.
  
 \subsection{Trigger Efficiency Calculation} \label{sec: Z trigger efficiency}
 The code \texttt{measure$\_$trigger$\_$eff.py} calculates the trigger efficiency $\varepsilon_{\rm trigger}$, which forms the dominant systematic error in Z cross section calculation. 
-Events where the positive muon or negative muon trigger are counted, as well as the events where both muons trigger. 
+Events where the positive muon or negative muon trigger are counted in the fiducial region (see \ref{sec: Z xsec}), as well as the events where both muons trigger. 
 By requiring that one muon triggers (the tag muon), then there is no bias on the other muon (the probe muon). Hence, the efficiency of the probe muon trigger can be calculated as:
 \begin{equation}
 {\varepsilon}_{{\rm probe \;  muon}} = \frac{{\rm number \; of \; events \; where \; both \; muons \; trigger}}{{\rm number \; of \; events \; where \; tag \; muon \; triggers}}.
 \end{equation}
 
-The trigger efficiency is then calculated as the efficiency of either muon causing a trigger to activate (TOS).
-Trigger efficiency and its relative uncertainty are output as a json file, with the trigger efficiency given in Section \ref{trigger_val}.
+This gives the trigger efficiencies of the positive and negative muons $\varepsilon_{\mu^+}$ and $\varepsilon_{\mu^-}$ as
+\begin{equation}
+    \varepsilon_{\mu^+} = \frac{N_{\mu^- + \mu^+}}{N_{\mu^-}},
+    \label{eq: mup_eff}
+\end{equation}
+\begin{equation}
+    \varepsilon_{\mu^-} = \frac{N_{\mu^- + \mu^+}}{N_{\mu^+}},
+    \label{eq: mum_eff}
+\end{equation}
+where $N$ represents the number of events where the indicated muon(s) triggers. These efficiencies are used in the determination of $W^+$ and $W^-$ cross sections respectively (see Section \ref{sec: W xsec}).
+The trigger efficiency used in the $Z$ analysis is calculated as the efficiency of either muon causing a trigger to activate (TOS), given as
+\begin{equation}
+    \varepsilon_{\mu\mu} = \varepsilon_{\mu^+} + \varepsilon_{\mu^-} - \varepsilon_{\mu^+} \times \varepsilon_{\mu^-}.
+    \label{eq: either eff}
+\end{equation}
+The relative uncertainty on each efficiency is determined using the binomial formula $\sqrt{\varepsilon(1-\varepsilon/N}$ where $N$ represents the sample size. In this analysis, $N$ is given as the number of $Z$ events in the fiducial region.
+The trigger efficiencies and their relative uncertainties are output as a json file ``efficiencies.json", with the trigger efficiencies given in Section \ref{trigger_val}.
 
-\subsection{Cross Section Calculation} \label{sec: Z xsec}
+\subsection{Z Cross Section Calculation} \label{sec: Z xsec}
 The code \texttt{measure$\_$xsec.py} calculates the integrated cross section of Z $\sigma_Z$.
-The number of events in the fiducial region are counted. The fiducial region is comprised of the kinematic cuts:
+The number of events in the fiducial region $N_{\rm fiducial}$ are counted. The fiducial region is comprised of the kinematic cuts:
 
 \begin{itemize}
   \item $60 < M_{\mu\mu} < 120 \; {\rm GeV}$ 
@@ -104,11 +120,23 @@ The number of events in the fiducial region are counted. The fiducial region is 
 
 $\sigma_Z$ is then calculated as
 \begin{equation}
-\sigma_Z = \frac{{\rm counts}}{L \times {\varepsilon_{\rm trigger}}},
+\sigma_Z = \frac{N_{\rm fiducial}}{L \times {\varepsilon_{\rm trigger}}},
+\label{eq: Z_xsec}
 \end{equation}
 using the previously calculated values of integrated luminosity $L$ and trigger efficiency $\varepsilon_{\rm trigger}$, read in from their respective codes.
 
-Error analysis on $\sigma_Z$ is carried out using the relative uncertainities on the number of counts, trigger efficiency, and luminosity. Each of these uncertainties is given separately in the result, with the uncertainty on the number of counts representing the statistical error. The cross section is output to a json file, and its value can be seen in Section \ref{xsec_val}, whilst the value of counts can be seen in Section \ref{counts_val}.
+Errors are propagated through $\sigma_Z$ according to the equation,
+\begin{equation}
+    \alpha_\sigma = \sigma \sqrt{\left(\frac{\alpha_N}{N}\right)^2 + \left(\frac{\alpha_L}{L}\right)^2 + \left(\frac{\alpha_\varepsilon}{\varepsilon}\right)^2},
+    \label{eq: xsec error}
+\end{equation}
+and given separately in the result as statistical error (from the number of counts), and errors due to efficiency and luminosity. Errors are separated according to the following equation, with the statistical error given as an example;
+\begin{equation}
+    \alpha_{\rm stat} = \frac{(\alpha_N/N)^2}{(\alpha_\sigma/\sigma)^2}\alpha_\sigma.
+    \label{eq: xsec error separation}
+\end{equation}
+%Error analysis on $\sigma_Z$ is carried out using the relative uncertainties on the number of counts, trigger efficiency, and luminosity. Each of these uncertainties is given separately in the result, with the uncertainty on the number of counts representing the statistical error. 
+The cross section is output to a json file ``Z$\_$xsec.output", and its value can be seen in Section \ref{xsec_val}, whilst the value of counts can be seen in Section \ref{counts_val}.
 
 
 \section{W Boson Analysis} \label{sec: W boson}
@@ -128,13 +156,13 @@ The $W$ decay signal can be seen as a peak between $p_T^{-1}$ = 0.02 and 0.03 Ge
 \begin{figure*}[t]
 \centering
 \includegraphics[clip, trim = 0.3cm 0.3cm 1.7cm 1.3cm,width=0.49\textwidth]{W+_isolated_signal.pdf}
-\includegraphics[clip, trim = 0.3cm 0.3cm 1.7cm 1.3cm,width=0.49\textwidth]{W-_isolated_signal.pdf} \hspace{3mm}
-\vspace{-8mm}
+\includegraphics[clip, trim = 0.3cm 0.3cm 1.7cm 1.3cm,width=0.49\textwidth]{W-_isolated_signal.pdf} %\hspace{3mm}
+\vspace{-4mm}
 \caption{\small Histogram plots of inverse transverse momentum $p_T^{-1}$ against the log of the isolation for the $W \xrightarrow{} \mu \nu_\mu$ decay. $W^+$ and $W^-$ are shown left and right respectively Plotted using the LEGO option.}
 \label{fig: LEGO}
 \end{figure*}
 
-\begin{figure}[!h]
+\begin{figure}[!hb]
     \centering
     \includegraphics[clip, trim = 0cm 0cm 0.3cm 1.3cm, width=\textwidth]{../doc/measurement_doc/W+_isolated_signal_COLZ.pdf}
     \vspace{-4mm}
@@ -161,7 +189,7 @@ The code includes a number of functions which carry out different parts of the a
     \item \texttt{background$\_$fit}: Analyses $\pi/K \xrightarrow{} \mu\nu$ background, fitting the W "SingleTrackNoBias" trees in the data with an exponential, and returning a Monte Carlo template of the fit. A plot of the exponential fit is output as a "png" file.
     \item \texttt{fraction$\_$fitter}: TFractionFitter is carried out on the background contributions, returning the fractions of each in the $W$ data. A plot of this fit is output as a "png file. 
     \item \texttt{produce$\_$fit$\_$model}: Produces a plot of the fit model, output as a "png" file. Each background contribution is scaled to the data by the fraction calculated in \texttt{fraction$\_$fitter}, and the fit model is calculated as the sum of all background contributions.
-    \item \texttt{output$\_$values}: Outputs numerical results of the code to a ``json'' file. The python code \texttt{make$\_$W$\_$latex.py} formats these outputs into latex forms, outputting ``tex'' files, which are input to this document.
+    \item \texttt{output$\_$values}: Outputs numerical results of the code to a ``json'' file. The python code \texttt{make$\_$W$\_$latex.py} formats these outputs into latex forms, outputting ``tex'' files, which are input to this document. The json files are ``Wp$\_$back$\_$output.json" and``Wm$\_$back$\_$output.json".
 \end{itemize}
 A structure \texttt{fit$\_$fractions} is also introduced to store the fit fractions calculated by the function \texttt{fraction$\_$fitter}. The structure includes the value and error of each fit fraction, along with the string used to label its value in a plot. This forms the output of the function \texttt{fraction$\_$fitter}, and is passed as an input to \texttt{produce$\_$fit$\_$model}.
 
@@ -221,7 +249,7 @@ The analysis is carried out in the following steps:
 Results of \texttt{W$\_$background.cpp} are listed below, and include Table~\ref{tab: W events}, and Figures~\ref{fig: W exp back fit}, \ref{fig: W fraction fit}, and \ref{fig: W fit model}.
 
 % Exponential fit of pion kaon background
-\begin{figure*}[h]
+\begin{figure*}[ht]
   \centering
   \includegraphics[clip, trim = 0.6cm 0.1cm 2.1cm 1.5cm, width=0.49\textwidth]{W+_expo_back_plot.png}
   \includegraphics[clip, trim = 0.6cm 0.1cm 2.1cm 1.5cm, width=0.49\textwidth]{W-_expo_back_plot.png} \hspace{3mm}
@@ -245,7 +273,7 @@ Results of \texttt{W$\_$background.cpp} are listed below, and include Table~\ref
 \input{results/Wm_fit_fracs_output.tex}
 
 % Fraction fitter plots
-\begin{figure*}[h]
+\begin{figure*}[hbt]
 \centering
 \includegraphics[clip, trim = 0.2cm 0.3cm 2.2cm 1.6cm, width=0.49\textwidth]{W+_fraction_fit.png}
 \includegraphics[clip, trim = 0.2cm 0.3cm 2.2cm 1.6cm, width=0.49\textwidth]{W-_fraction_fit.png} 
@@ -255,7 +283,7 @@ Results of \texttt{W$\_$background.cpp} are listed below, and include Table~\ref
 \end{figure*}
 
 % Fit model plots
-\begin{figure*}[h]
+\begin{figure*}[ht]
 \centering
 \includegraphics[clip, trim = 0.2cm 0.3cm 2.2cm 1.6cm, width=0.49\textwidth]{W+_fit_model.png}
 \includegraphics[clip, trim = 0.2cm 0.3cm 2.2cm 1.6cm, width=0.49\textwidth]{W-_fit_model.png} 
@@ -265,9 +293,11 @@ Results of \texttt{W$\_$background.cpp} are listed below, and include Table~\ref
 \end{figure*}
 
 
-\section{W Cross Section and Cross Section Ratio Determination}
-The code \texttt{measure$\_$W$\_$xsec.py} calculates the $W^+$ and $W^-$ cross sections, and calculates the cross section ratios $W^+/W^-$ and $W/Z$. Values used in this calculation are read in from json files produced in the codes \texttt{W$\_$background.cpp}, \texttt{get$\_$luminosity.py}, and \texttt{measure$\_$xsec.py} (see Sections \ref{sec: W background}, \ref{sec: Z lumi}, and \ref{sec: Z xsec} respectively). Results are output as json files, and formatted to a tex file in the code \texttt{make$\_$W$\_$latex.py}, similarly to \texttt{W$\_$background.cpp}.
+\section{W Cross Section and Cross Section Ratio Determination} \label{sec: W xsec}
+The code \texttt{measure$\_$W$\_$xsec.py} calculates the $W^+$ and $W^-$ cross sections, and calculates the cross section ratios $W^+/W^-$ ($R_{WW}$) and $W/Z$ ($R_{WZ}$). Values used in this calculation are read in from json files produced in the codes \texttt{W$\_$background.cpp}, \texttt{get$\_$luminosity.py}, \texttt{measure$\_$trigger$\_$eff.py}, and \texttt{measure$\_$xsec.py} (see Sections \ref{sec: W background}, \ref{sec: Z lumi}, \ref{sec: Z trigger efficiency}, and \ref{sec: Z xsec} respectively). Results are output as json files, ``Wp$\_$xsec.json", ``Wm$\_$xsec.json", and ``Ratios.json". These are formatted to tex files in the code \texttt{make$\_$W$\_$latex.py}, similarly to \texttt{W$\_$background.cpp}.
+The results of this analysis are given in Section~\ref{sec: results}.
 
+\subsection{W Cross Sections}
 Each cross section is determined in the function \texttt{xsec$\_$calc}. Background subtraction is carried on the $W$ experimental data, determining the expected number of $W$ events in the signal $N_{\rm signal}$ as
 \begin{equation}
     N_{\rm signal} = N_W \times {\rm f}_{\rm signal},
@@ -279,39 +309,89 @@ where $N_W$ is the total number of $W$ events in the data after event selection,
 The cross section of each $W$ boson $\sigma_W$ is subsequently calculated as
 \begin{equation}
     \sigma_W = \frac{N_{\rm signal}}{L \times \varepsilon_{\rm trigger}},
+    \label{eq: W_xsec}
 \end{equation}
-where $L$ is luminosity and $\varepsilon_{\rm trigger}$ is the trigger efficiency. The error on this value is given separately as statistical error, error due to trigger efficiency and luminosity error.
-The trigger efficiency used here is the same value previously calculated for $Z\xrightarrow{}\mu\mu$ decays in the program \texttt{measure$\_$trigger$\_$eff.py}, as given in Section \ref{trigger_val} and used in the calculation of the $Z$ boson cross section $\sigma_Z$. 
-As $W$ boson decays only produce one muon, there is no redundancy with which to calculate trigger efficiency; if a muon does not activate a trigger, no event will be counted. The muon will either trigger or not. Conversely, in the $Z$ boson decay, two muons are produced, allowing for the trigger efficiency to be measured according to whether one or both muons activate the trigger in each event.
+where $L$ is luminosity and $\varepsilon_{\rm trigger}$ is the trigger efficiency. The error on this value is given separately as statistical error, error due to trigger efficiency, and luminosity error, determined using Equations~\ref{eq: xsec error} and \ref{eq: xsec error separation}.
+The trigger efficiencies used here are $\varepsilon_{\mu^+}$ and $\varepsilon_{\mu^-}$ for $W^+$ and $W^-$ respectively, as given in Equations~\ref{eq: mup_eff} and \ref{eq: mum_eff}. These are calculated in the program \texttt{measure$\_$trigger$\_$eff.py} and their values given in Section \ref{trigger_val}. 
 
-The ratio $W^+/W^-$ is calculated as 
-\begin{equation}
-    \frac{W^+}{W^-} = \frac{\sigma_{W^+}}{\sigma_{W^-}}.    
-\end{equation}
-As luminosity cancels from this equation, the dominant errors imposed on the cross section measurements by luminosity can be ignored. This similarly occurs for trigger efficiency. 
-This leaves the statistical error as the only error contribution.
-%, although in later analysis, errors produced by the trigger efficiency will also contribute. 
-Hence, errors can be propagated as follows,
-\begin{equation}
-    \frac{\alpha_{W^+/W^-}}{W^+/W^-} = \sqrt{\left(\frac{\alpha_{\sigma_{W^+}}}{\sigma_{W^+}}\right)^2 + \left(\frac{\alpha_{\sigma_{W^-}}}{\sigma_{W^-}}\right)^2} = \sqrt{\left(\frac{\alpha_{\sigma_{W^+} \rm stat}}{\sigma_{W^+}}\right)^2 + \left(\frac{\alpha_{\sigma_{W^-} \rm stat}}{\sigma_{W^-}}\right)^2}.
-\end{equation}
+As $W$ boson decays only produce one muon, there is no redundancy with which to calculate trigger efficiency; if a muon does not activate a trigger, no event will be counted. The muon will either trigger or not. Conversely, in the $Z$ boson decay, two muons are produced, allowing for the trigger efficiency to be measured according to whether one or both muons activate the trigger in each event. Hence, the trigger efficiency has to be calculated using the $Z$ boson data rather than $W$. It is assumed that the trigger efficiency is independent of the muon kinematics.
 
-The ratio of $W$ to $Z$ boson cross sections $W/Z$ is calculated as
-\begin{equation}
-    \frac{W}{Z} = \frac{\sigma_{W^+} + \sigma_{W^-}}{\sigma_{Z}},
-\end{equation}
-and similarly to the $W^+/W^-$ ratio, luminosity and trigger efficiency cancel, producing the following error propagation
-\begin{equation}
-    \frac{\alpha_{W/Z}}{W/Z} = \sqrt{\frac{\alpha_{\sigma_{W^+}}^2+\alpha_{\sigma_{W^-}}^2}{(\sigma_{W^+}+\sigma_{W^-})^2} + \left(\frac{\alpha_{\sigma_{Z}}}{\sigma_{Z}}\right)^2} = \sqrt{\frac{\alpha_{\sigma_{W^+} \rm stat }^2+\alpha_{\sigma_{W^-} \rm stat}^2}{(\sigma_{W^+}+\sigma_{W^-})^2} + \left(\frac{\alpha_{\sigma_{Z}\rm stat}}{\sigma_{Z}}\right)^2}.
-\end{equation}
-
-The results of this analysis are as follows:
+The $W$ cross sections are found to be
 \input{results/Wp_xsec_output.tex}
 \input{results/Wm_xsec_output.tex}
-\input{results/WW_ratio_output.tex}
-\input{results/WZ_ratio_output.tex}
 
-\section{Results}
+% WW Ratio
+\subsection{WW Ratio}
+The ratio of $W^+/W^-$, $R_{WW}$, is calculated using cross sections, with the ratio given in terms of Equation~\ref{eq: W_xsec} for purposes of error propagation;
+\begin{equation}
+    R_{WW} = \frac{\sigma_{W^+}}{\sigma_{W^-}} = \frac{N_{W^+}}{\varepsilon_{\mu^+}} \cdot \frac{\varepsilon_{\mu^-}}{N_{W^-}}.    
+\end{equation}
+where $N_{W^+}$ and $N_{W^-}$ are the $N_{\rm signal}$ used in $\sigma_{W^+}$ and $\sigma_{W^-}$ determination respectively.
+As luminosity cancels from this equation, the dominant errors imposed on the cross section measurements by luminosity can be ignored.
+This leaves the statistical and efficiency errors as the only error contributions.
+Hence, errors can be propagated as follows,
+\begin{equation}
+    \alpha_{WW} = R_{WW}\sqrt{\left(\frac{\alpha_{N_{W^+}}}{N_{W^+}}\right)^2 + \left(\frac{\alpha_{N_{W^-}}}{N_{W^-}}\right)^2 + \left(\frac{\alpha_{\varepsilon_{\mu^+}}}{\varepsilon_{\mu^+}}\right)^2 + \left(\frac{\alpha_{\varepsilon_{\mu^-}}}{\varepsilon_{\mu^-}}\right)^2}.
+\end{equation}
+Using Equation~\ref{eq: xsec error separation}, this can be set in terms of the statistical and efficiency errors of $\sigma_{W^+}$ and $\sigma_{W^-}$ as,
+\begin{equation}
+       \alpha_{WW} = R_{WW}\sqrt{C_{W+} \cdot \alpha_{\sigma_{W+} \rm stat} + C_{W-} \cdot \alpha_{\sigma_{W-}\rm stat} + C_{W+} \cdot \alpha_{\sigma_{W+} \rm eff} + C_{W-} \cdot \alpha_{\sigma_{W-}\rm eff}}.
+       \label{eq: WW errors}
+\end{equation}
+where $C_{W+}$ and $C_{W-}$ are coefficients found to be,
+\begin{equation}
+    C_{W+} = \frac{\alpha_{\sigma{W+}}}{{\sigma_{W^+}}^2}, \quad {\rm and} \quad C_{W-} = \frac{\alpha_{\sigma{W-}}}{{\sigma_{W^-}}^2}.
+    \label{eq: Wp Wm separation coeffs}
+\end{equation}
+The statistical and efficiency errors on the cross sections in Equation~\ref{eq: WW errors} are grouped together to find the statistical and efficiency errors on $R_{WW}$ in a similar method to Equation~\ref{eq: xsec error separation}, giving the final separated errors on the $R_{WW}$. The statistical error on $R_{WW}$ is given as an example;
+\begin{equation}
+    \alpha_{WW \rm stat} = \frac{(C_{W+} \cdot \alpha_{\sigma_{W+} \rm stat} + C_{W-} \cdot \alpha_{\sigma_{W-}\rm stat})}{(\alpha_{WW}/{R_{WW}})^2} \alpha_{WW}.
+\end{equation}
+The $W^+/W^-$ ratio is found to be
+\input{results/WW_ratio_output}
+
+\subsection{WZ Ratio}
+% WZ Ratio
+The ratio of $W$ to $Z$ boson cross sections $W/Z$, $R_{WZ}$, is calculated using cross sections, with the ratio given in terms of Equation~\ref{eq: W_xsec} for purposes of error propagation;
+\begin{equation}
+    R_{WZ} = \frac{\sigma_{W^+} + \sigma_{W^-}}{\sigma_{Z}} = \left( \frac{N_{W^+}}{\varepsilon_{\mu^+}} + \frac{N_{W^-}}{\varepsilon_{\mu^-}} \right) \cdot \frac{\varepsilon_{\mu\mu}}{N_{Z}},
+\end{equation}
+where $\varepsilon_{\mu\mu}$ is the trigger efficiency of either muon in a $Z$ decay, given in Equation~\ref{eq: either eff}, and $N_Z$ is $N_{\rm fiducial}$ in Equation~\ref{eq: Z_xsec}.
+Similarly to $R_{WW}$, luminosity cancels, removing it from error propagation. The error on $R_{WZ}$ can be propagated as follows, with coefficients $A$ and $B$ given below,
+\begin{equation}
+        \frac{\alpha_{WZ}}{R_{WZ}} = \sqrt{
+            A\cdot\left(\frac{\alpha_{N_{W^+}}}{N_{W^+}}\right)^2 + B\cdot\left(\frac{\alpha_{N_{W^-}}}{N_{W^-}}\right)^2 + \left(\frac{\alpha_{N_{Z}}}{N_{Z}}\right)^2 + A\cdot\left(\frac{\alpha_{\varepsilon_{\mu^+}}}{\varepsilon_{\mu^+}}\right)^2 + B\cdot\left(\frac{\alpha_{\varepsilon_{\mu^-}}}{\varepsilon_{\mu^-}}\right)^2 + \left(\frac{\alpha_{\varepsilon_{\mu\mu}}}{\varepsilon_{\mu\mu}}\right)^2
+        },
+\end{equation}
+\begin{equation}
+    A = \left(\frac{N_{W^+}}{\varepsilon_{\mu^+}}\right)^2 \bigg/ \left(\frac{N_{W^+}}{\varepsilon_{\mu^+}} + \frac{N_{W^-}}{\varepsilon_{\mu^-}}\right)^2, \quad {\rm and} \quad B = \left(\frac{N_{W^-}}{\varepsilon_{\mu^-}}\right)^2 \bigg/ \left(\frac{N_{W^+}}{\varepsilon_{\mu^+}} + \frac{N_{W^-}}{\varepsilon_{\mu^-}}\right)^2.
+\end{equation}
+Using Equation~\ref{eq: xsec error separation}, this can be set in terms of the statistical and efficiency errors of $\sigma_{W^+}$ and $\sigma_{W^-}$ as,
+\begin{equation}
+        \alpha_{WZ} = R_{WZ}\sqrt{
+            \begin{aligned}
+                A \cdot C_{W+} \cdot \alpha_{\sigma_{W+} \rm stat} + B \cdot C_{W-} \cdot \alpha_{\sigma_{W-}\rm stat} + C_{Z} \cdot \alpha_{\sigma_{Z}\rm stat} \\
+                + A \cdot C_{W+} \cdot \alpha_{\sigma_{W+} \rm eff} + B \cdot C_{W-} \cdot \alpha_{\sigma_{W-}\rm eff} + C_{Z} \cdot \alpha_{\sigma_{Z}\rm eff}
+            \end{aligned}
+        },
+        \label{eq: WZ errors}
+\end{equation}
+where $C_{W+}$ and $C_{W-}$ are given in Equation~\ref{eq: Wp Wm separation coeffs}, with $C_Z$ calculated similarly using $\alpha_{\sigma_Z}$ and $\sigma_Z$. The statistical and efficiency errors on the cross sections are grouped together to find the statistical and efficiency errors on $R_{WZ}$, as before for $R_{WW}$, with statistical error given as an example;
+\begin{equation}
+    \alpha_{WZ \rm stat} = \frac{(A \cdot C_{W+} \cdot \alpha_{\sigma_{W+} \rm stat} + B \cdot C_{W-} \cdot \alpha_{\sigma_{W-}\rm stat} + C_Z \cdot \alpha_{\sigma_{Z} \rm stat})}{(\alpha_{WZ}/R_{WZ})^2} \alpha_{WZ}.
+\end{equation}
+The $W/Z$ ratio is found to be
+\input{results/WZ_ratio_output}
+
+
+%\subsection{Results of W Analysis}
+%The results of this analysis are as follows:
+%\input{results/Wp_xsec_output.tex}
+%\input{results/Wm_xsec_output.tex}
+%\input{results/WW_ratio_output.tex}
+%\input{results/WZ_ratio_output.tex}
+
+\section{Results} \label{sec: results}
 The overall results of the entire analysis are as follows; electroweak production in $pp$ collisions at $\sqrt{s}=5$ TeV,
 \input{results/Z_xsec_output.tex}
 \input{results/Wp_xsec_output.tex}
@@ -329,7 +409,7 @@ These comparison figures are plotted in the code \texttt{plot$\_$xsec.py}.
     \centering
     \begin{tabular}{c|ll}
         \hline
-         Energy (TeV)   & $W^+/W^-$ & $W/Z$  \\
+         Energy (TeV)   & $R_{WW}$ & $R_{WZ}$  \\
         \hline
          5              & \input{results/WW_value.tex}  & \input{results/WZ_value.tex}  \\
          7              & 1.274 $\pm$ 0.005 $\pm$ 0.009 $\pm$ 0.002 & 20.63 $\pm$ 0.09 $\pm$ 0.12 $\pm$ 0.05  \\
@@ -340,17 +420,18 @@ These comparison figures are plotted in the code \texttt{plot$\_$xsec.py}.
     \label{tab: ratio comparison}
 \end{table}
 
-There is good agreement between our $W^+/W^-$ ratio and published results. However, our $W/Z$ ratio is higher than these previous results. This would suggest that either the determined $Z$ cross section is too small, or the $W$ cross sections could be too large. Comparing the $W$ cross sections at each energy (as seen in Table~\ref{tab: xsec comparison}), I would propose that the $W$ cross sections are too large; there is a significant difference between 7 and 8 TeV, which is not seen between 5 and 7 TeV. For this larger gap in energy, I would expect a large difference in cross section, as seen in the $Z$ cross section. These differences will become more apparent in plotting the cross sections as a function $\sqrt{s}$, the next step in this analysis.
+There is good agreement between our $R_{WW}$ ratio and published results. However, our $R_{WZ}$ ratio is higher than these previous results. This would suggest that either the determined $Z$ cross section is too small, or the $W$ cross sections could be too large. Comparing the $W$ cross sections at each energy (as seen in Table~\ref{tab: xsec comparison}), I would propose that the $W$ cross sections are too large; there is a significant difference between 7 and 8 TeV, which is not seen between 5 and 7 TeV. For this larger gap in energy, I would expect a large difference in cross section, as seen in the $Z$ cross section. These differences will become more apparent in plotting the cross sections as a function $\sqrt{s}$, the next step in this analysis.
 
 \begin{table}[]
     \centering
+    \footnotesize
     \begin{tabular}{c|lll}
         \hline
-        \small $\sqrt{s}$ (TeV)   & \small $\sigma_{Z}$ (pb) & \small $\sigma_{W^+}$ (pb) & \small $\sigma_{W^-}$ (pb)  \\
+         $\sqrt{s}$ (TeV)   &  $\sigma_{Z}$ (pb) &  $\sigma_{W^+}$ (pb) &  $\sigma_{W^-}$ (pb)  \\
         \hline
-         5              & \small \input{results/Z_xsec_value.tex}  & \small \input{results/Wp_xsec_value.tex} & \small \input{results/Wm_xsec_value}\\
-         7              & \small 76.0 $\pm$ 0.3 $\pm$ 0.5 $\pm$ 1.0 $\pm$ 1.3 & \small 861.0 $\pm$ 2.0 $\pm$ 11.2 $\pm$ 14.7 & \small 675.8 $\pm$ 1.9 $\pm$ 8.8 $\pm$ 11.6\\
-         8              & \small 95.0 $\pm$ 0.3 $\pm$ 0.7 $\pm$ 1.1 $\pm$ 1.1 & \small 1093.6 $\pm$ 2.1 $\pm$ 7.2 $\pm$ 10.9 $\pm$ 12.7 & \small 818.4 $\pm$ 1.9 $\pm$ 5.0 $\pm$ 7.0 $\pm$ 9.5\\
+         5              &  \input{results/Z_xsec_value.tex}  &  \input{results/Wp_xsec_value.tex} &  \input{results/Wm_xsec_value}\\
+         7              &  76.0 $\pm$ 0.3 $\pm$ 0.5 $\pm$ 1.0 $\pm$ 1.3 &  861.0 $\pm$ 2.0 $\pm$ 11.2 $\pm$ 14.7 &  675.8 $\pm$ 1.9 $\pm$ 8.8 $\pm$ 11.6\\
+         8              &  95.0 $\pm$ 0.3 $\pm$ 0.7 $\pm$ 1.1 $\pm$ 1.1 &  1093.6 $\pm$ 2.1 $\pm$ 7.2 $\pm$ 10.9 $\pm$ 12.7 &  818.4 $\pm$ 1.9 $\pm$ 5.0 $\pm$ 7.0 $\pm$ 9.5\\
          \hline
     \end{tabular}
     \caption{\small Comparison of cross sections determined at LHCb at $\sqrt{s} =$ 5, 7, and 8 TeV. Errors on 7 TeV $W$ values are statistical, systematic, and luminosity. On 8 TeV and $Z$ for 7 TeV, the errors are statistical, systematic, due to beam energy, and luminosity. The 7 TeV values were measured at luminosity of 1.0 fb$^{-1}$, and 8 TeV values at 2.0 fb$^{-1}$~\cite{7TeV_W_2014,7TeV_Z_2015,8TeV_W+Z_2015}.}
@@ -377,7 +458,7 @@ There is good agreement between our $W^+/W^-$ ratio and published results. Howev
 \end{figure*}
 
 
-\section{Future Work}
+\section{Future Work} \label{sec: future work}
 \subsection{Monte Carlo Comparison of Z data for 5 TeV Measurement} \label{Z histograms}
 The use of the simulations used in data analysis should be validated by comparison with the $Z$ experimental data. 
 The plots in Figure~\ref{fig: Z histograms} are comparisons of the $Z$ data with a Monte Carlo simulation of $Z$ produced at $\sqrt{s}=$5 TeV which had undergone detector reconstruction (\texttt{5TeV$\_$2015$\_$24r1$\_$Down$\_$Z$\_$Sim09d.root}). 
@@ -386,7 +467,7 @@ The simulation data has been scaled to the experimental data, each histogram plo
 
 Comparison of these plots can be used to correct for imperfections in the detector and to remove background from measurements, although the simulation is limited in precision to leading order by \textsc{Pythia} and by the precision to which the detector can be described.
 
-\begin{figure*}[p]
+\begin{figure*}[bt]
 \centering
 \includegraphics[clip, trim = 0.5cm 0cm 1.7cm 1.3cm, width=0.49\textwidth]{Measurement_mup_PT.png}
 \includegraphics[clip, trim = 0.5cm 0cm 1.7cm 1.3cm, width=0.49\textwidth]{Measurement_mum_PT.png}

--- a/doc/measurement_doc/measurement_report.tex
+++ b/doc/measurement_doc/measurement_report.tex
@@ -82,11 +82,11 @@ The error on luminosity is assumed to be 5$\%$.
 Integrated luminosity and its error are output as a json file, with their values given in Section \ref{lumi_val}.
  
 \subsection{Trigger Efficiency Calculation} \label{sec: Z trigger efficiency}
-The code \texttt{measure$\_$trigger$\_$eff.py} calculates the trigger efficiency, which forms the dominant systematic error in Z cross section calculation. 
+The code \texttt{measure$\_$trigger$\_$eff.py} calculates the trigger efficiency $\varepsilon_{\rm trigger}$, which forms the dominant systematic error in Z cross section calculation. 
 Events where the positive muon or negative muon trigger are counted, as well as the events where both muons trigger. 
 By requiring that one muon triggers (the tag muon), then there is no bias on the other muon (the probe muon). Hence, the efficiency of the probe muon trigger can be calculated as:
 \begin{equation}
-{\rm efficiency}_{{\rm probe \;  muon}} = \frac{{\rm number \; of \; events \; where \; both \; muons \; trigger}}{{\rm number \; of \; events \; where \; tag \; muon \; triggers}}.
+{\varepsilon}_{{\rm probe \;  muon}} = \frac{{\rm number \; of \; events \; where \; both \; muons \; trigger}}{{\rm number \; of \; events \; where \; tag \; muon \; triggers}}.
 \end{equation}
 
 The trigger efficiency is then calculated as the efficiency of either muon causing a trigger to activate (TOS).
@@ -104,9 +104,9 @@ The number of events in the fiducial region are counted. The fiducial region is 
 
 $\sigma_Z$ is then calculated as
 \begin{equation}
-\sigma_Z = \frac{{\rm counts}}{L \times {\rm \; trigger \; efficiency}},
+\sigma_Z = \frac{{\rm counts}}{L \times {\varepsilon_{\rm trigger}}},
 \end{equation}
-using the previously calculated values of integrated luminosity $L$ and trigger efficiency, read in from their respective codes.
+using the previously calculated values of integrated luminosity $L$ and trigger efficiency $\varepsilon_{\rm trigger}$, read in from their respective codes.
 
 Error analysis on $\sigma_Z$ is carried out using the relative uncertainities on the number of counts, trigger efficiency, and luminosity. Each of these uncertainties is given separately in the result, with the uncertainty on the number of counts representing the statistical error. The cross section is output to a json file, and its value can be seen in Section \ref{xsec_val}, whilst the value of counts can be seen in Section \ref{counts_val}.
 
@@ -278,15 +278,20 @@ where $N_W$ is the total number of $W$ events in the data after event selection,
 \end{equation}
 The cross section of each $W$ boson $\sigma_W$ is subsequently calculated as
 \begin{equation}
-    \sigma_W = \frac{N_{\rm signal}}{L},
+    \sigma_W = \frac{N_{\rm signal}}{L \times \varepsilon_{\rm trigger}},
 \end{equation}
-where $L$ is luminosity. The error on this value is given separately as statistical error and luminosity error.
+where $L$ is luminosity and $\varepsilon_{\rm trigger}$ is the trigger efficiency. The error on this value is given separately as statistical error, error due to trigger efficiency and luminosity error.
+The trigger efficiency used here is the same value previously calculated for $Z\xrightarrow{}\mu\mu$ decays in the program \texttt{measure$\_$trigger$\_$eff.py}, as given in Section \ref{trigger_val} and used in the calculation of the $Z$ boson cross section $\sigma_Z$. 
+As $W$ boson decays only produce one muon, there is no redundancy with which to calculate trigger efficiency; if a muon does not activate a trigger, no event will be counted. The muon will either trigger or not. Conversely, in the $Z$ boson decay, two muons are produced, allowing for the trigger efficiency to be measured according to whether one or both muons activate the trigger in each event.
 
 The ratio $W^+/W^-$ is calculated as 
 \begin{equation}
     \frac{W^+}{W^-} = \frac{\sigma_{W^+}}{\sigma_{W^-}}.    
 \end{equation}
-As luminosity cancels from this equation, the dominant errors imposed on the cross section measurements by luminosity can be ignored. This leaves the statistical error as the only error contribution, although in later analysis, errors produced by the trigger efficiency will also contribute. Hence, errors can be propagated as follows,
+As luminosity cancels from this equation, the dominant errors imposed on the cross section measurements by luminosity can be ignored. This similarly occurs for trigger efficiency. 
+This leaves the statistical error as the only error contribution.
+%, although in later analysis, errors produced by the trigger efficiency will also contribute. 
+Hence, errors can be propagated as follows,
 \begin{equation}
     \frac{\alpha_{W^+/W^-}}{W^+/W^-} = \sqrt{\left(\frac{\alpha_{\sigma_{W^+}}}{\sigma_{W^+}}\right)^2 + \left(\frac{\alpha_{\sigma_{W^-}}}{\sigma_{W^-}}\right)^2} = \sqrt{\left(\frac{\alpha_{\sigma_{W^+} \rm stat}}{\sigma_{W^+}}\right)^2 + \left(\frac{\alpha_{\sigma_{W^-} \rm stat}}{\sigma_{W^-}}\right)^2}.
 \end{equation}
@@ -295,7 +300,7 @@ The ratio of $W$ to $Z$ boson cross sections $W/Z$ is calculated as
 \begin{equation}
     \frac{W}{Z} = \frac{\sigma_{W^+} + \sigma_{W^-}}{\sigma_{Z}},
 \end{equation}
-and similarly to the $W^+/W^-$ ratio, luminosity cancels, producing the following error propagation
+and similarly to the $W^+/W^-$ ratio, luminosity and trigger efficiency cancel, producing the following error propagation
 \begin{equation}
     \frac{\alpha_{W/Z}}{W/Z} = \sqrt{\frac{\alpha_{\sigma_{W^+}}^2+\alpha_{\sigma_{W^-}}^2}{(\sigma_{W^+}+\sigma_{W^-})^2} + \left(\frac{\alpha_{\sigma_{Z}}}{\sigma_{Z}}\right)^2} = \sqrt{\frac{\alpha_{\sigma_{W^+} \rm stat }^2+\alpha_{\sigma_{W^-} \rm stat}^2}{(\sigma_{W^+}+\sigma_{W^-})^2} + \left(\frac{\alpha_{\sigma_{Z}\rm stat}}{\sigma_{Z}}\right)^2}.
 \end{equation}

--- a/scripts/make_W_latex.py
+++ b/scripts/make_W_latex.py
@@ -45,14 +45,15 @@ def xsec_output (save_path, boson, label, json_in):
     xsec = json_in["xsec"]
     xsec_err_stat = json_in["xsec_err_stat"]
     xsec_err_lumi = json_in["xsec_err_lumi"]
+    xsec_err_eff = json_in["xsec_err_eff"]
 
     with open(save_path+boson+'_xsec_output.tex', 'w') as texfile:
         texfile.write("\\"+"begin{equation}\n")
-        texfile.write("\sigma_{} = {:.{prec}f} \pm {:.{prec}f}_{{\\rm stat}} \pm {:.{prec}f}_{{\\rm lumi}} \; {{\\rm pb}},\n".format(label, xsec, xsec_err_stat, xsec_err_lumi, prec=0))
+        texfile.write("\sigma_{} = {:.{prec}f} \pm {:.{prec}f}_{{\\rm stat}} \pm {:.{prec}f}_{{\\rm eff}} \pm {:.{prec}f}_{{\\rm lumi}} \; {{\\rm pb}},\n".format(label, xsec, xsec_err_stat, xsec_err_eff, xsec_err_lumi, prec=1))
         texfile.write("\\"+"end{equation}\n")
     
     with open(save_path+boson+'_xsec_value.tex', 'w') as texfile:
-        texfile.write("${:.{prec}f} \pm {:.{prec}f}_{{\\rm stat}} \pm {:.{prec}f}_{{\\rm lumi}}$".format(xsec, xsec_err_stat, xsec_err_lumi, prec=0))
+        texfile.write("${:.{prec}f} \pm {:.{prec}f}_{{\\rm stat}} \pm {:.{prec}f}_{{\\rm eff}} \pm {:.{prec}f}_{{\\rm lumi}}$".format(xsec, xsec_err_stat, xsec_err_eff, xsec_err_lumi, prec=1))
 
 
 with open('results_json/Wp_back_output.json') as json_file:

--- a/scripts/make_W_latex.py
+++ b/scripts/make_W_latex.py
@@ -49,11 +49,11 @@ def xsec_output (save_path, boson, label, json_in):
 
     with open(save_path+boson+'_xsec_output.tex', 'w') as texfile:
         texfile.write("\\"+"begin{equation}\n")
-        texfile.write("\sigma_{} = {:.{prec}f} \pm {:.{prec}f}_{{\\rm stat}} \pm {:.{prec}f}_{{\\rm eff}} \pm {:.{prec}f}_{{\\rm lumi}} \; {{\\rm pb}},\n".format(label, xsec, xsec_err_stat, xsec_err_eff, xsec_err_lumi, prec=1))
+        texfile.write("\sigma_{} = {:.{prec}f} \pm {:.{prec}f}_{{\\rm stat}} \pm {:.{prec}f}_{{\\rm eff}} \pm {:.{prec}f}_{{\\rm lumi}} \; {{\\rm pb}},\n".format(label, xsec, xsec_err_stat, xsec_err_eff, xsec_err_lumi, prec=2))
         texfile.write("\\"+"end{equation}\n")
     
     with open(save_path+boson+'_xsec_value.tex', 'w') as texfile:
-        texfile.write("${:.{prec}f} \pm {:.{prec}f}_{{\\rm stat}} \pm {:.{prec}f}_{{\\rm eff}} \pm {:.{prec}f}_{{\\rm lumi}}$".format(xsec, xsec_err_stat, xsec_err_eff, xsec_err_lumi, prec=1))
+        texfile.write("${:.{prec}f} \pm {:.{prec}f} \pm {:.{prec}f} \pm {:.{prec}f}$".format(xsec, xsec_err_stat, xsec_err_eff, xsec_err_lumi, prec=2))
 
 
 with open('results_json/Wp_back_output.json') as json_file:
@@ -93,20 +93,24 @@ xsec_output(save_path, "Wm", Wm_decay, Wm_xsec_input)
 # ratios
 WW_ratio = Ratios["WW_ratio"]
 WW_ratio_err = Ratios["WW_error"]
+WW_ratio_stat = Ratios["WW_stat"]
+WW_ratio_eff = Ratios["WW_eff"]
 with open(save_path+'WW_ratio_output.tex','w') as texfile:
     texfile.write("\\"+"begin{equation}\n")
-    texfile.write("\\frac{{\sigma_{}}}{{\sigma_{}}} = {:.{prec}f} \pm {:.{prec}f},\n".format(Wp_decay, Wm_decay, WW_ratio, WW_ratio_err, prec=2))
+    texfile.write("\\frac{{\sigma_{}}}{{\sigma_{}}} = {:.{prec}f} \pm {:.{prec}f}_{{\\rm stat}} \pm {:.{prec}f}_{{\\rm eff}},\n".format(Wp_decay, Wm_decay, WW_ratio, WW_ratio_stat, WW_ratio_eff, prec=4))
     texfile.write("\\"+"end{equation}\n")
 
 with open(save_path+'WW_value.tex','w') as texfile:
-    texfile.write("${:.{prec}f} \pm {:.{prec}f}$".format(WW_ratio, WW_ratio_err, prec=2))
+    texfile.write("${:.{prec}f} \pm {:.{prec}f} \pm {:.{prec}f}$".format(WW_ratio, WW_ratio_stat, WW_ratio_eff, prec=4))
 
 WZ_ratio = Ratios["WZ_ratio"]
 WZ_ratio_err = Ratios["WZ_error"]
+WZ_ratio_stat = Ratios["WZ_stat"]
+WZ_ratio_eff = Ratios["WZ_eff"]
 with open(save_path+'WZ_ratio_output.tex','w') as texfile:
     texfile.write("\\"+"begin{equation}\n")
-    texfile.write("\\frac{{\sigma_{}+\sigma_{}}}{{\sigma_{}}} = {:.{prec}f} \pm {:.{prec}f}.\n".format(Wp_decay, Wm_decay, Z_decay, WZ_ratio, WZ_ratio_err, prec=1))
+    texfile.write("\\frac{{\sigma_{}+\sigma_{}}}{{\sigma_{}}} = {:.{prec}f} \pm {:.{prec}f}_{{\\rm stat}} \pm {:.{prec}f}_{{\\rm eff}}.\n".format(Wp_decay, Wm_decay, Z_decay, WZ_ratio, WZ_ratio_stat, WZ_ratio_eff, prec=3))
     texfile.write("\\"+"end{equation}\n")
 
 with open(save_path+'WZ_value.tex','w') as texfile:
-    texfile.write("${:.{prec}f} \pm {:.{prec}f}$".format(WZ_ratio, WZ_ratio_err, prec=1))
+    texfile.write("${:.{prec}f} \pm {:.{prec}f} \pm {:.{prec}f}$".format(WZ_ratio, WZ_ratio_stat, WZ_ratio_eff, prec=3))

--- a/scripts/measure_W_xsec.py
+++ b/scripts/measure_W_xsec.py
@@ -13,11 +13,11 @@ def xsec_calc(W_data, lumi, lumi_err, trig_eff, trig_eff_rel_unc):
     counts_err = counts * math.sqrt((signal_frac_err/signal_frac)*(signal_frac_err/signal_frac) + W_events_rel_unc*W_events_rel_unc)
 
     xsec = counts/(lumi*trig_eff)
-    xsec_err_stat = xsec * (counts_err/counts)
-    xsec_err_lumi = xsec * (lumi_err/lumi)    
-    xsec_err_eff = xsec * trig_eff_rel_unc
-    xsec_err = xsec_err_stat + xsec_err_lumi + xsec_err_eff
-
+    xsec_err = xsec*math.sqrt((counts_err/counts)**2+(lumi_err/lumi)**2+trig_eff_rel_unc**2)
+    xsec_err_stat = xsec_err * (counts_err/counts)**2/(xsec_err/xsec)**2
+    xsec_err_lumi = xsec_err * (lumi_err/lumi)**2/(xsec_err/xsec)**2    
+    xsec_err_eff = xsec_err * trig_eff_rel_unc**2/(xsec_err/xsec)**2
+    #print("{} added vs {} propagation".format(xsec_err_stat+xsec_err_lumi+xsec_err_eff,xsec_err))
     return xsec, xsec_err, xsec_err_stat, xsec_err_lumi, xsec_err_eff, counts, counts_err
 
 
@@ -31,9 +31,10 @@ lumi_err = luminosity["luminosity_err"]
 # retrieve trigger efficiency
 with open('results_json/efficiencies.json') as json_file:
     efficiencies = json.load(json_file)
-trig_eff = efficiencies["trigger_efficiency"]
-trig_eff_rel_unc = efficiencies["trigger_eff_error"]
-
+mup_eff = efficiencies["mup_efficiency"]
+mup_eff_rel_unc = efficiencies["mup_eff_error"]
+mum_eff = efficiencies["mum_efficiency"]
+mum_eff_rel_unc = efficiencies["mum_eff_error"]
 
 # retrive background data
 with open('results_json/Wp_back_output.json') as json_file:
@@ -43,8 +44,8 @@ with open('results_json/Wm_back_output.json') as json_file:
     Wm_back = json.load(json_file)
 
 # calculate cross sections
-Wp_xsec, Wp_xsec_err, Wp_xsec_err_stat, Wp_xsec_err_lumi, Wp_xsec_err_eff, Wp_events, Wp_events_err = xsec_calc(Wp_back, lumi, lumi_err, trig_eff, trig_eff_rel_unc)
-Wm_xsec, Wm_xsec_err, Wm_xsec_err_stat, Wm_xsec_err_lumi, Wm_xsec_err_eff, Wm_events, Wm_events_err = xsec_calc(Wm_back, lumi, lumi_err, trig_eff, trig_eff_rel_unc)
+Wp_xsec, Wp_xsec_err, Wp_xsec_err_stat, Wp_xsec_err_lumi, Wp_xsec_err_eff, Wp_events, Wp_events_err = xsec_calc(Wp_back, lumi, lumi_err, mup_eff, mup_eff_rel_unc)
+Wm_xsec, Wm_xsec_err, Wm_xsec_err_stat, Wm_xsec_err_lumi, Wm_xsec_err_eff, Wm_events, Wm_events_err = xsec_calc(Wm_back, lumi, lumi_err, mum_eff, mum_eff_rel_unc)
 
 # output cross sections
 Wp_xsec_output = {"count":Wp_events, "count_error":Wp_events_err, "xsec":Wp_xsec, "xsec_err":Wp_xsec_err, "xsec_err_stat":Wp_xsec_err_stat, "xsec_err_lumi":Wp_xsec_err_lumi, "xsec_err_eff":Wp_xsec_err_eff}
@@ -58,18 +59,28 @@ with open('results_json/Wm_xsec.json', 'w') as outfile:
 
 #print('Wp events = {} + {}'.format(Wp_events, Wp_events_err))
 #print('Wp xsec = {} + {}'.format(Wp_xsec, Wp_xsec_err))
-#print('Wp xsec = {} + {} + {}'.format(Wp_xsec, Wp_xsec_err_stat, Wp_xsec_err_lumi))
+#print('Wp xsec = {} + {} + {} + {}'.format(Wp_xsec, Wp_xsec_err_stat, Wp_xsec_err_eff, Wp_xsec_err_lumi))
 
 #print('Wm events = {} + {}'.format(Wm_events, Wm_events_err))
 #print('Wm xsec = {} + {}'.format(Wm_xsec, Wm_xsec_err))
-#print('Wm xsec = {} + {} + {}'.format(Wm_xsec, Wm_xsec_err_stat, Wm_xsec_err_lumi))
+#print('Wm xsec = {} + {} + {} + {}'.format(Wm_xsec, Wm_xsec_err_stat, Wm_xsec_err_eff, Wm_xsec_err_lumi))
 
 
 # calculate Wp/Wm ratio
 Wp_Wm_ratio = Wp_xsec/Wm_xsec
-Wp_Wm_ratio_err = Wp_Wm_ratio * math.sqrt((Wp_xsec_err_stat/Wp_xsec)**2+(Wm_xsec_err_stat/Wm_xsec)**2)
+Wp_stat = Wp_xsec_err/(Wp_xsec**2) * Wp_xsec_err_stat
+Wm_stat = Wm_xsec_err/(Wm_xsec**2) * Wm_xsec_err_stat
+Wp_eff  = Wp_xsec_err/(Wp_xsec**2) * Wp_xsec_err_eff
+Wm_eff  = Wm_xsec_err/(Wm_xsec**2) * Wm_xsec_err_eff
+Wp_Wm_ratio_err = Wp_Wm_ratio * math.sqrt(Wp_stat + Wm_stat + Wp_eff + Wm_eff)
+Wp_Wm_ratio_stat= Wp_Wm_ratio_err * (Wp_stat + Wm_stat)/((Wp_Wm_ratio_err/Wp_Wm_ratio)**2)
+Wp_Wm_ratio_eff = Wp_Wm_ratio_err * (Wp_eff + Wm_eff)/((Wp_Wm_ratio_err/Wp_Wm_ratio)**2)
 
-#print('Wp/Wm = {} + {}'.format(Wp_Wm_ratio, Wp_Wm_ratio_err))
+# testing and output
+#r = Wp_events/Wm_events * mum_eff/mup_eff
+#r_err = r*math.sqrt((Wp_events_err/Wp_events)**2 + (Wm_events_err/Wm_events)**2 + mum_eff_rel_unc**2 + mup_eff_rel_unc**2)
+#print('Wp/Wm = {} + {} stat + {} eff'.format(Wp_Wm_ratio, Wp_Wm_ratio_stat, Wp_Wm_ratio_eff))
+#print('Wp/Wm = {} + {} separate + {} derived + {} propagated'.format(r, Wp_Wm_ratio_stat+Wp_Wm_ratio_eff, r_err, Wp_Wm_ratio_err))
 
 # calculate (Wp+Wm)/Z ratio
 #retrieve Z xsec
@@ -78,13 +89,41 @@ with open('results_json/Z_xsec.json') as Z_xsec_file:
 Z_xsec = Z_xsec_input["xsec"]
 Z_xsec_err = Z_xsec_input["xsec_err"]
 Z_xsec_err_stat = Z_xsec_input["xsec_err_stat"]
+Z_xsec_err_eff = Z_xsec_input["xsec_err_eff"]
+
+Z_events = Z_xsec_input["count"]
+Z_events_rel_unc = Z_xsec_input["count_rel_uncertainty"] 
+either_eff = efficiencies["trigger_efficiency"]
+either_eff_rel_unc = efficiencies["trigger_eff_error"]
 
 W_Z_ratio = (Wp_xsec+Wm_xsec)/Z_xsec
-W_Z_ratio_err = W_Z_ratio * math.sqrt((Wp_xsec_err_stat**2 + Wm_xsec_err_stat**2)/(Wp_xsec + Wm_xsec)**2 + (Z_xsec_err_stat/Z_xsec)**2)
+Z_stat = Z_xsec_err/(Z_xsec**2) * Z_xsec_err_stat
+Z_eff = Z_xsec_err/(Z_xsec**2) * Z_xsec_err_eff
 
-#print('W/Z = {} + {}'.format(W_Z_ratio, W_Z_ratio_err))
+Wp_coeff = ((Wp_events/mup_eff)**2)/((Wp_events/mup_eff + Wm_events/mum_eff)**2)
+Wm_coeff = ((Wm_events/mum_eff)**2)/((Wp_events/mup_eff + Wm_events/mum_eff)**2)
+
+W_Z_ratio_err = W_Z_ratio * math.sqrt(Wp_coeff*Wp_stat + Wm_coeff*Wm_stat + Z_stat + Wp_coeff*Wp_eff + Wm_coeff*Wm_eff + Z_eff)
+W_Z_ratio_stat = W_Z_ratio_err * (Wp_coeff*Wp_stat + Wm_coeff*Wm_stat + Z_stat)/((W_Z_ratio_err/W_Z_ratio)**2)
+W_Z_ratio_eff = W_Z_ratio_err * (Wp_coeff*Wp_eff + Wm_coeff*Wm_eff + Z_eff)/((W_Z_ratio_err/W_Z_ratio)**2)
+
+#print('W/Z = {} + {} + {}'.format(W_Z_ratio, W_Z_ratio_stat, W_Z_ratio_eff))
 
 # output ratios
-ratio_output = {"WW_ratio":Wp_Wm_ratio, "WW_error":Wp_Wm_ratio_err, "WZ_ratio":W_Z_ratio, "WZ_error":W_Z_ratio_err}
+ratio_output = {"WW_ratio":Wp_Wm_ratio, "WW_error":Wp_Wm_ratio_err, "WW_stat":Wp_Wm_ratio_stat, "WW_eff":Wp_Wm_ratio_eff, "WZ_ratio":W_Z_ratio, "WZ_error":W_Z_ratio_err, "WZ_stat":W_Z_ratio_stat, "WZ_eff":W_Z_ratio_eff}
 with open('results_json/Ratios.json','w') as outfile:
     json.dump(ratio_output,outfile)
+
+# testing and output
+#pos_err = (Wp_events/mup_eff)*math.sqrt((mup_eff_rel_unc)**2+(Wp_events_err/Wp_events)**2)
+#neg_err = (Wm_events/mum_eff)*math.sqrt((mum_eff_rel_unc)**2+(Wm_events_err/Wm_events)**2)
+#W_err = math.sqrt(pos_err**2 + neg_err**2)
+#numerator = (Wp_events/mup_eff)+(Wm_events/mum_eff) 
+#R = (numerator)/(Z_events/either_eff)
+#R_err = R*math.sqrt((W_err/numerator)**2 + either_eff_rel_unc**2 + Z_events_rel_unc**2)
+
+#A = (Wp_events/mup_eff)**2/numerator**2
+#B = (Wm_events/mum_eff)**2/numerator**2
+#print("A = {}, B = {}, wp coef = {}, wm coef = {}".format(A,B,Wp_coeff,Wm_coeff))
+
+#print("Separate = {} + {}, derived = {} + {}, propagated = {} + {}".format(W_Z_ratio, W_Z_ratio_stat+W_Z_ratio_eff, R, R_err, W_Z_ratio, W_Z_ratio_err))

--- a/scripts/measure_trigger_eff.py
+++ b/scripts/measure_trigger_eff.py
@@ -11,22 +11,28 @@ file_path = "/storage/epp2/phshgg/DVTuples__v23/5TeV_2017_32_Down_EW.root"
 ch = ROOT.TChain('Z/DecayTree')
 ch.Add(file_path)
 
-mup_trigger = float(ch.GetEntries("mup_L0MuonDecision_TOS == 1"))
-mum_trigger = float(ch.GetEntries("mum_L0MuonDecision_TOS == 1"))
-both_trigger = float(ch.GetEntries("mup_L0MuonDecision_TOS == 1 && mum_L0MuonDecision_TOS == 1"))
-N_total = float(ch.GetEntries())
+fiducial_cuts = "Z_M > 60.e3 && Z_M < 120.e3 && mup_PT > 20.e3 && mum_PT > 20.e3 && mup_ETA > 2 && mup_ETA < 4.5 && mum_ETA > 2 && mum_ETA < 4.5"
+
+mup_trigger = float(ch.GetEntries(fiducial_cuts + " && mup_L0MuonDecision_TOS == 1"))
+mum_trigger = float(ch.GetEntries(fiducial_cuts + " && mum_L0MuonDecision_TOS == 1"))
+both_trigger = float(ch.GetEntries(fiducial_cuts + " && mup_L0MuonDecision_TOS == 1 && mum_L0MuonDecision_TOS == 1"))
+N_total = float(ch.GetEntries(fiducial_cuts))
 
 mup_eff = both_trigger/mum_trigger
+mup_eff_err = math.sqrt(mup_eff*(1-mup_eff)/N_total)
+
 mum_eff = both_trigger/mup_trigger
+mum_eff_err = math.sqrt(mum_eff*(1-mum_eff)/N_total)
 
 mup_mum_eff = mup_eff + mum_eff - mup_eff * mum_eff
 mup_mum_eff_err = math.sqrt(mup_mum_eff*(1-mup_mum_eff)/N_total)
 
 
-#print("Trigger Efficiency = {}".format(mup_mum_eff))
-#print("Trigger Efficiency Relative Uncertainty = {}".format(mup_mum_eff_err))
+#print("Either Trigger Efficiency = {}".format(mup_mum_eff))
+#print("Either Trigger Efficiency Relative Uncertainty = {}".format(mup_mum_eff_err))
+#print("mup = {}, mum = {}, either = {}".format(mup_eff, mum_eff, mup_mum_eff))
 
-data ={"mup":mup_eff, "mum":mum_eff, "trigger_efficiency":mup_mum_eff, "trigger_eff_error":mup_mum_eff_err}
+data ={"mup_efficiency":mup_eff, "mup_eff_error":mup_eff_err, "mum_efficiency":mum_eff, "mum_eff_error":mum_eff_err, "trigger_efficiency":mup_mum_eff, "trigger_eff_error":mup_mum_eff_err}
 
 with open('results_json/efficiencies.json', 'w') as outfile:
     json.dump(data,outfile)
@@ -35,5 +41,9 @@ current_dir = os.getcwd()
 save_path = os.path.join(current_dir, 'doc/measurement_doc/results/')
 
 with open(save_path+'trig_eff_output.tex', 'w') as texfile:
-    texfile.write("Trigger Efficiency $\\varepsilon_{{\\rm trigger}}$ = ${:.{prec}f} \pm {:.{prec}f}$\\\\".format(mup_mum_eff, mup_mum_eff*mup_mum_eff_err, prec=4))
-    texfile.write("Trigger Efficiency Relative Uncertainty = ${:.{prec}f}$\\\\".format(mup_mum_eff_err, prec=5))
+    texfile.write("Positive muon $\mu^+$ Trigger Efficiency $\\varepsilon^{{\mu^+}}$ = ${:.{prec}f} \pm {:.{prec}f}$\\\\".format(mup_eff, mup_eff*mup_eff_err, prec=3))
+    texfile.write("Positive muon relative uncertainty = ${:.{prec}f}$\\\\".format(mup_eff_err, prec=4))
+    texfile.write("Negative muon $\mu^-$ Trigger Efficiency $\\varepsilon^{{\mu^-}}$ = ${:.{prec}f} \pm {:.{prec}f}$\\\\".format(mum_eff, mum_eff*mum_eff_err, prec=3))
+    texfile.write("Negative muon relative uncertainty = ${:.{prec}f}$\\\\".format(mum_eff_err, prec=4))
+    texfile.write("Trigger Efficiency of Either muon $\\varepsilon^{{\mu\mu}}_{{\\rm trigger}}$ = ${:.{prec}f} \pm {:.{prec}f}$\\\\".format(mup_mum_eff, mup_mum_eff*mup_mum_eff_err, prec=4))
+    texfile.write("Either muon Relative Uncertainty = ${:.{prec}f}$\\\\".format(mup_mum_eff_err, prec=5))

--- a/scripts/measure_trigger_eff.py
+++ b/scripts/measure_trigger_eff.py
@@ -35,6 +35,5 @@ current_dir = os.getcwd()
 save_path = os.path.join(current_dir, 'doc/measurement_doc/results/')
 
 with open(save_path+'trig_eff_output.tex', 'w') as texfile:
-    texfile.write("Trigger Efficiency = ${:.{prec}f} \pm {:.{prec}f}$\\\\".format(mup_mum_eff, mup_mum_eff*mup_mum_eff_err, prec=4))
+    texfile.write("Trigger Efficiency $\\varepsilon_{{\\rm trigger}}$ = ${:.{prec}f} \pm {:.{prec}f}$\\\\".format(mup_mum_eff, mup_mum_eff*mup_mum_eff_err, prec=4))
     texfile.write("Trigger Efficiency Relative Uncertainty = ${:.{prec}f}$\\\\".format(mup_mum_eff_err, prec=5))
-

--- a/scripts/measure_xsec.py
+++ b/scripts/measure_xsec.py
@@ -13,7 +13,7 @@ ch.Add(file_path)
 
 count = ch.GetEntries("Z_M > 60.e3 && Z_M < 120.e3 && mup_PT > 20.e3 && mum_PT > 20.e3 && mup_ETA > 2 && mup_ETA < 4.5 && mum_ETA > 2 && mum_ETA < 4.5")
 
-count_err = math.sqrt(count)/count
+count_rel_unc = math.sqrt(count)/count
 
 with open('results_json/luminosity.json') as json_file:
     luminosity = json.load(json_file)
@@ -25,26 +25,25 @@ with open('results_json/efficiencies.json') as json_file:
     efficiencies = json.load(json_file)
 
 trig_eff = efficiencies["trigger_efficiency"]
-trig_eff_err = efficiencies["trigger_eff_error"]
+trig_eff_rel_unc = efficiencies["trigger_eff_error"]
 
 xsec = count/(lumi*trig_eff)
-xsec_err = xsec * (count_err + trig_eff_err + lumi_err/lumi)
 
-xsec_err_stat = xsec * count_err
-xsec_err_eff = xsec * trig_eff_err
-xsec_err_lumi = xsec * lumi_err/lumi
+xsec_err = xsec*math.sqrt((count_rel_unc)**2+(lumi_err/lumi)**2+trig_eff_rel_unc**2)
+xsec_err_stat = xsec_err * (count_rel_unc)**2/(xsec_err/xsec)**2
+xsec_err_lumi = xsec_err * (lumi_err/lumi)**2/(xsec_err/xsec)**2    
+xsec_err_eff = xsec_err * trig_eff_rel_unc**2/(xsec_err/xsec)**2
 
 #print('Z Count = {}'.format(count))
-#print('Z Count Relative Uncertainty = {}'.format(count_err))
+#print('Z Count Relative Uncertainty = {}'.format(count_rel_unc))
 
 #print('Z Cross Section (pb) = {}'.format(xsec))
 #print('XSec Error (pb) = {}'.format(xsec_err))
-
 #print('Stat Error (pb) = {}'.format(xsec_err_stat))
 #print('Efficiency Error (pb) = {}'.format(xsec_err_eff))
 #print('Luminosity Error (pb) = {}'.format(xsec_err_lumi))
 
-data_output = {"count":count, "count_rel_uncertainty":count_err, "xsec":xsec, "xsec_err":xsec_err, "xsec_err_stat":xsec_err_stat, "xsec_err_eff":xsec_err_eff, "xsec_err_lumi":xsec_err_lumi}
+data_output = {"count":count, "count_rel_uncertainty":count_rel_unc, "xsec":xsec, "xsec_err":xsec_err, "xsec_err_stat":xsec_err_stat, "xsec_err_eff":xsec_err_eff, "xsec_err_lumi":xsec_err_lumi}
 
 with open('results_json/Z_xsec.json', 'w') as outfile:
     json.dump(data_output,outfile)
@@ -59,12 +58,12 @@ save_path = os.path.join(current_dir, 'doc/measurement_doc/results/')
 
 with open(save_path+'Z_xsec_output.tex', 'w') as texfile:
     texfile.write("\\"+"begin{equation}\n")
-    texfile.write("\sigma_{{Z\\xrightarrow{{}}\mu^+\mu^-}} = {:.{prec}f} \pm {:.{prec}f}_{stat_txt} \pm {:.{prec}f}_{eff_txt} \pm {:.{prec}f}_{lumi_txt} \; {xsec_unit},\n".format(xsec, xsec_err_stat, xsec_err_eff, xsec_err_lumi, stat_txt=stat_txt,  eff_txt=eff_txt, lumi_txt=lumi_txt, xsec_unit=xsec_unit, prec=2))
+    texfile.write("\sigma_{{Z\\xrightarrow{{}}\mu^+\mu^-}} = {:.{prec}f} \pm {:.{prec}f}_{stat_txt} \pm {:.{prec}f}_{eff_txt} \pm {:.{prec}f}_{lumi_txt} \; {xsec_unit},\n".format(xsec, xsec_err_stat, xsec_err_eff, xsec_err_lumi, stat_txt=stat_txt,  eff_txt=eff_txt, lumi_txt=lumi_txt, xsec_unit=xsec_unit, prec=3))
     texfile.write("\\"+"end{equation}")
 
 with open(save_path+'counts_output.tex', 'w') as texfile:
-    texfile.write("Counts in Fiducial Region = ${} \pm {:.0f} \; \\rm counts$\\\\".format(count, count*count_err))
-    texfile.write("Counts Relative Uncertainty = ${:.4f}$\\\\".format(count_err))
+    texfile.write("Counts in Fiducial Region = ${} \pm {:.0f} \; \\rm counts$\\\\".format(count, count*count_rel_unc))
+    texfile.write("Counts Relative Uncertainty = ${:.4f}$\\\\".format(count_rel_unc))
 
 with open(save_path+'Z_xsec_value.tex', 'w') as texfile:
-    texfile.write("${:.{prec}f} \pm {:.{prec}f}_{stat_txt} \pm {:.{prec}f}_{eff_txt} \pm {:.{prec}f}_{lumi_txt}$".format(xsec, xsec_err_stat, xsec_err_eff, xsec_err_lumi, stat_txt=stat_txt,  eff_txt=eff_txt, lumi_txt=lumi_txt, prec=2))
+    texfile.write("${:.{prec}f} \pm {:.{prec}f} \pm {:.{prec}f} \pm {:.{prec}f}$".format(xsec, xsec_err_stat, xsec_err_eff, xsec_err_lumi, stat_txt=stat_txt,  eff_txt=eff_txt, lumi_txt=lumi_txt, prec=3))


### PR DESCRIPTION
@mvesteri 
Trigger efficiency has been included in the W xsec analysis. See report: [measurement_report.pdf](https://github.com/r-preston/MPhysProject2021/files/6023220/measurement_report.pdf).

I had a question regarding the error propagation of trigger efficiency in the ratios. As we are using the same value for each cross section, the trigger efficiency cancels out of the ratios, the same as luminosity, and hence would not appear in the ratio errors. However in each of the LHCb papers I have read, the error due to trigger efficiency is included in the ratio error propagation. Why is this the case?
